### PR TITLE
Fix list rendering issue with strikethrough text

### DIFF
--- a/DWtest.php
+++ b/DWtest.php
@@ -136,7 +136,18 @@ $test11 = <<<MD
 $test11_p
 MD;
 
-$test = ltrim($test11_p);
+$test12 = '## List test
+### Unordered List
+- ~~item 1~~
+- **item 2**
+- item 3
+
+### Ordered List
+1. ~~item 1~~
+2. **item 2**
+3. item 3';
+
+$test = ltrim($test12);
 echo $test . "\n\n=========================\n\n";
 $result = Commonmark::RendtoDW($test);
 echo $result;

--- a/src/Dokuwiki/Plugin/Commonmark/Extension/Renderer/Block/ListItemRenderer.php
+++ b/src/Dokuwiki/Plugin/Commonmark/Extension/Renderer/Block/ListItemRenderer.php
@@ -37,7 +37,7 @@ final class ListItemRenderer implements NodeRendererInterface
         ListItem::assertInstanceOf($node);
 
         $result = $DWRenderer->renderNodes($node->children());
-        if (\substr($result, 0, 1) === '<' && !$this->startsTaskListItem($block)) {
+        if (\substr($result, 0, 1) === '<' && \substr($result, 0, 5) !== '<del>' && !$this->startsTaskListItem($node)) {
             $result = "\n" . $result;
         }
         if (\substr($result, -1, 1) === '>') {


### PR DESCRIPTION
List items that start with strikethrough content cause a `PHP Warning:  Undefined variable $block in ListItemRenderer.php on line 40`. I assume that in 94a075ee9c5821074e0d7b2c07e7e230fefe6cd9 when `$block` was replaced with `$node`, the one occurrence in line 40 was overlooked.

Changing this to `$node` doesn't fully fix the issue, because an additional newline is added, which messes up the rendering. So I  added an additional check to not add this newline if the rendered content starts with `<del>`. There is probably a nicer way of doing this, but it seems to work just fine.

I additionally added the following test case to illustrate the issue:

```md
## List test
### Unordered List
- ~~item 1~~
- **item 2**
- item 3

### Ordered List
1. ~~item 1~~
2. **item 2**
3. item 3
```