### PR TITLE
feat: add image alignment parameter

### DIFF
--- a/DWtest.php
+++ b/DWtest.php
@@ -136,7 +136,19 @@ $test11 = <<<MD
 $test11_p
 MD;
 
-$test = ltrim($test11_p);
+$test12 = '## Image Alignment
+![](test.jpg)
+
+![](test.jpg?align=left)
+
+![](test.jpg?align=right)
+
+![](test.jpg?align=center)
+
+![](test.jpg?align=right&400)
+';
+
+$test = ltrim($test12);
 echo $test . "\n\n=========================\n\n";
 $result = Commonmark::RendtoDW($test);
 echo $result;

--- a/src/Dokuwiki/Plugin/Commonmark/Extension/Renderer/Inline/ImageRenderer.php
+++ b/src/Dokuwiki/Plugin/Commonmark/Extension/Renderer/Inline/ImageRenderer.php
@@ -41,6 +41,7 @@ final class ImageRenderer implements NodeRendererInterface, ConfigurationAwareIn
     {
         Image::assertInstanceOf($node);
 
+        $args = null;
         $attrs = $node->data->get('attributes');
 
         $forbidUnsafeLinks = !$this->config->get('allow_unsafe_links');
@@ -48,6 +49,7 @@ final class ImageRenderer implements NodeRendererInterface, ConfigurationAwareIn
             $attrs['src'] = '';
         } else {
             $attrs['src'] = $node->getUrl();
+            \parse_str(\parse_url($node->getUrl(), PHP_URL_QUERY), $args);
         }
 
         $alt = $DWRenderer->renderNodes($node->children());
@@ -58,8 +60,12 @@ final class ImageRenderer implements NodeRendererInterface, ConfigurationAwareIn
             $attrs['title'] = $node->data['title'];
         }
 
-        $result = '{{' . $attrs['src'];
-        $attrs['alt'] ? $result.= '|' . $attrs['alt'] . '}}' : $result.= '}}';
+        $result = '{{' . (isset($args['align']) && ($args['align'] === 'right' || $args['align'] === 'center') ? ' ' : '');
+        $result.= $attrs['src'] . (isset($args['align']) && ($args['align'] === 'left' || $args['align'] === 'center') ? ' ' : '');
+        if ($attrs['alt']) {
+            $result.= '|' . trim($attrs['alt']);
+        }
+        $result.= '}}';
 
         return $result;
     }   


### PR DESCRIPTION
One limitation of this plugin in contrast to dokuwiki's native markup is that images can't be aligned. This pull request adds another image query parameter for image alignment, which is then translated to dokuwiki's image alignment by adding spaces before or after the image url.

For example `![](test.jpg?align=right)` is translated into `{{ test.jpg?align=right}}`. The parameter itself is then ignored by dokuwiki.

Image alignment in commonmark seems to be a controversial topic and my approach is adding a behavior that is not compatible with regular commonmark. I don't see any harm in doing this, since other dokuwiki specific query parameters (such as width and nolink) are also supported. But maybe this change is not desired.