### PR TITLE
Fix spurious spaces around inline elements

### DIFF
--- a/DWtest.php
+++ b/DWtest.php
@@ -147,7 +147,9 @@ $test12 = '## List test
 2. **item 2**
 3. item 3';
 
-$test = ltrim($test12);
+$test13 = 'Inline markup and punctuation: **Bold**, *Italic*, `fixed-width`.';
+
+$test = ltrim($test13);
 echo $test . "\n\n=========================\n\n";
 $result = Commonmark::RendtoDW($test);
 echo $result;

--- a/src/Dokuwiki/Plugin/Commonmark/DWRenderer.php
+++ b/src/Dokuwiki/Plugin/Commonmark/DWRenderer.php
@@ -69,7 +69,7 @@ final class DWRenderer implements ChildNodeRendererInterface
         $isFirstItem = true;
 
         foreach ($nodes as $node) {
-            if (! $isFirstItem && $node instanceof Node) {
+            if (! $isFirstItem && $node instanceof AbstractBlock) {
                 $output .= $this->getBlockSeparator();
             }
 


### PR DESCRIPTION
Without this fix, the code adds a block separator after each element,
which translates to a space before and after each element, including
bold, italics, etc. This is especially visible when the element is
followed by punctuation.

The fix makes the code only add a block separator after block elements.